### PR TITLE
Fixed compiling issues with xna and monogame projects.

### DIFF
--- a/src/Content/.gitignore
+++ b/src/Content/.gitignore
@@ -1,2 +1,3 @@
 /bin/
 /obj/
+/*.user

--- a/src/Engine/.gitignore
+++ b/src/Engine/.gitignore
@@ -1,2 +1,3 @@
 /obj/
 /bin/
+/*.cachefile

--- a/src/Engine/Audio/AudioConfig.cs
+++ b/src/Engine/Audio/AudioConfig.cs
@@ -1,6 +1,8 @@
 ﻿/*
- * Copyright (C) 2011-2012 Volumetric Studios
+ * Copyright (C) 2011 - 2013 Voxeliq Engine - http://www.voxeliq.org - https://github.com/raistlinthewiz/voxeliq
  *
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the Microsoft Public License (Ms-PL).
  */
 
 using VoxeliqEngine.Configuration;

--- a/src/Engine/Audio/AudioManager.cs
+++ b/src/Engine/Audio/AudioManager.cs
@@ -1,6 +1,8 @@
 ﻿/*
- * Copyright (C) 2011-2012 Volumetric Studios
+ * Copyright (C) 2011 - 2013 Voxeliq Engine - http://www.voxeliq.org - https://github.com/raistlinthewiz/voxeliq
  *
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the Microsoft Public License (Ms-PL).
  */
 
 using System;

--- a/src/Engine/Blocks/Block.cs
+++ b/src/Engine/Blocks/Block.cs
@@ -1,6 +1,8 @@
 ﻿/*
- * Copyright (C) 2011-2012 Volumetric Studios
+ * Copyright (C) 2011 - 2013 Voxeliq Engine - http://www.voxeliq.org - https://github.com/raistlinthewiz/voxeliq
  *
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the Microsoft Public License (Ms-PL).
  */
 
 namespace VoxeliqEngine.Blocks

--- a/src/Engine/Blocks/BlockStorage.cs
+++ b/src/Engine/Blocks/BlockStorage.cs
@@ -1,6 +1,8 @@
 ﻿/*
- * Copyright (C) 2011-2012 Volumetric Studios
+ * Copyright (C) 2011 - 2013 Voxeliq Engine - http://www.voxeliq.org - https://github.com/raistlinthewiz/voxeliq
  *
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the Microsoft Public License (Ms-PL).
  */
 
 using Microsoft.Xna.Framework;

--- a/src/Engine/Chunks/Chunk.cs
+++ b/src/Engine/Chunks/Chunk.cs
@@ -1,6 +1,8 @@
 ﻿/*
- * Copyright (C) 2011-2012 Volumetric Studios
+ * Copyright (C) 2011 - 2013 Voxeliq Engine - http://www.voxeliq.org - https://github.com/raistlinthewiz/voxeliq
  *
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the Microsoft Public License (Ms-PL).
  */
 
 using System;

--- a/src/Engine/Chunks/ChunkCache.cs
+++ b/src/Engine/Chunks/ChunkCache.cs
@@ -1,6 +1,8 @@
 ﻿/*
- * Copyright (C) 2011-2012 Volumetric Studios
+ * Copyright (C) 2011 - 2013 Voxeliq Engine - http://www.voxeliq.org - https://github.com/raistlinthewiz/voxeliq
  *
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the Microsoft Public License (Ms-PL).
  */
 
 using System;

--- a/src/Engine/Chunks/ChunkState.cs
+++ b/src/Engine/Chunks/ChunkState.cs
@@ -1,6 +1,8 @@
 ﻿/*
- * Copyright (C) 2011-2012 Volumetric Studios
+ * Copyright (C) 2011 - 2013 Voxeliq Engine - http://www.voxeliq.org - https://github.com/raistlinthewiz/voxeliq
  *
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the Microsoft Public License (Ms-PL).
  */
 
 namespace VoxeliqEngine.Chunks

--- a/src/Engine/Chunks/ChunkStorage.cs
+++ b/src/Engine/Chunks/ChunkStorage.cs
@@ -1,6 +1,8 @@
 ﻿/*
- * Copyright (C) 2011-2012 Volumetric Studios
+ * Copyright (C) 2011 - 2013 Voxeliq Engine - http://www.voxeliq.org - https://github.com/raistlinthewiz/voxeliq
  *
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the Microsoft Public License (Ms-PL).
  */
 
 using System.Collections.Generic;

--- a/src/Engine/Chunks/Generators/Biomes/AntarticTundra.cs
+++ b/src/Engine/Chunks/Generators/Biomes/AntarticTundra.cs
@@ -1,6 +1,8 @@
 ﻿/*
- * Copyright (C) 2011-2012 Volumetric Studios
+ * Copyright (C) 2011 - 2013 Voxeliq Engine - http://www.voxeliq.org - https://github.com/raistlinthewiz/voxeliq
  *
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the Microsoft Public License (Ms-PL).
  */
 
 using VoxeliqEngine.Blocks;

--- a/src/Engine/Chunks/Generators/Biomes/BiomeGenerator.cs
+++ b/src/Engine/Chunks/Generators/Biomes/BiomeGenerator.cs
@@ -1,6 +1,8 @@
 ﻿/*
- * Copyright (C) 2011-2012 Volumetric Studios
+ * Copyright (C) 2011 - 2013 Voxeliq Engine - http://www.voxeliq.org - https://github.com/raistlinthewiz/voxeliq
  *
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the Microsoft Public License (Ms-PL).
  */
 
 namespace VoxeliqEngine.Chunks.Generators.Biomes

--- a/src/Engine/Chunks/Generators/Biomes/Desert.cs
+++ b/src/Engine/Chunks/Generators/Biomes/Desert.cs
@@ -1,6 +1,8 @@
 ﻿/*
- * Copyright (C) 2011-2012 Volumetric Studios
+ * Copyright (C) 2011 - 2013 Voxeliq Engine - http://www.voxeliq.org - https://github.com/raistlinthewiz/voxeliq
  *
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the Microsoft Public License (Ms-PL).
  */
 
 using VoxeliqEngine.Blocks;

--- a/src/Engine/Chunks/Generators/Biomes/RainForest.cs
+++ b/src/Engine/Chunks/Generators/Biomes/RainForest.cs
@@ -1,6 +1,8 @@
 ﻿/*
- * Copyright (C) 2011-2012 Volumetric Studios
+ * Copyright (C) 2011 - 2013 Voxeliq Engine - http://www.voxeliq.org - https://github.com/raistlinthewiz/voxeliq
  *
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the Microsoft Public License (Ms-PL).
  */
 
 using System;

--- a/src/Engine/Chunks/Generators/Terrain/BiomedTerrain.cs
+++ b/src/Engine/Chunks/Generators/Terrain/BiomedTerrain.cs
@@ -1,6 +1,8 @@
 ﻿/*
- * Copyright (C) 2011-2012 Volumetric Studios
+ * Copyright (C) 2011 - 2013 Voxeliq Engine - http://www.voxeliq.org - https://github.com/raistlinthewiz/voxeliq
  *
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the Microsoft Public License (Ms-PL).
  */
 
 using VoxeliqEngine.Blocks;

--- a/src/Engine/Chunks/Generators/Terrain/FlatDebugTerrain.cs
+++ b/src/Engine/Chunks/Generators/Terrain/FlatDebugTerrain.cs
@@ -1,6 +1,8 @@
 ﻿/*
- * Copyright (C) 2011-2012 Volumetric Studios
+ * Copyright (C) 2011 - 2013 Voxeliq Engine - http://www.voxeliq.org - https://github.com/raistlinthewiz/voxeliq
  *
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the Microsoft Public License (Ms-PL).
  */
 
 using VoxeliqEngine.Blocks;

--- a/src/Engine/Chunks/Generators/Terrain/MountainousTerrain.cs
+++ b/src/Engine/Chunks/Generators/Terrain/MountainousTerrain.cs
@@ -1,6 +1,8 @@
 ﻿/*
- * Copyright (C) 2011-2012 Volumetric Studios
+ * Copyright (C) 2011 - 2013 Voxeliq Engine - http://www.voxeliq.org - https://github.com/raistlinthewiz/voxeliq
  *
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the Microsoft Public License (Ms-PL).
  */
 
 using VoxeliqEngine.Chunks.Generators.Biomes;

--- a/src/Engine/Chunks/Generators/Terrain/TerrainGenerator.cs
+++ b/src/Engine/Chunks/Generators/Terrain/TerrainGenerator.cs
@@ -1,6 +1,8 @@
 ﻿/*
- * Copyright (C) 2011-2012 Volumetric Studios
+ * Copyright (C) 2011 - 2013 Voxeliq Engine - http://www.voxeliq.org - https://github.com/raistlinthewiz/voxeliq
  *
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the Microsoft Public License (Ms-PL).
  */
 
 namespace VoxeliqEngine.Chunks.Generators.Terrain

--- a/src/Engine/Chunks/Generators/Terrain/ValleyTerrain.cs
+++ b/src/Engine/Chunks/Generators/Terrain/ValleyTerrain.cs
@@ -1,6 +1,8 @@
 ﻿/*
- * Copyright (C) 2011-2012 Volumetric Studios
+ * Copyright (C) 2011 - 2013 Voxeliq Engine - http://www.voxeliq.org - https://github.com/raistlinthewiz/voxeliq
  *
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the Microsoft Public License (Ms-PL).
  */
 
 using VoxeliqEngine.Blocks;

--- a/src/Engine/Chunks/Processors/Lightning.cs
+++ b/src/Engine/Chunks/Processors/Lightning.cs
@@ -1,6 +1,8 @@
 ﻿/*
- * Copyright (C) 2011-2012 Volumetric Studios
+ * Copyright (C) 2011 - 2013 Voxeliq Engine - http://www.voxeliq.org - https://github.com/raistlinthewiz/voxeliq
  *
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the Microsoft Public License (Ms-PL).
  */
 
 using VoxeliqEngine.Blocks;

--- a/src/Engine/Chunks/Processors/VertexBuilder.cs
+++ b/src/Engine/Chunks/Processors/VertexBuilder.cs
@@ -1,6 +1,8 @@
 ﻿/*
- * Copyright (C) 2011-2012 Volumetric Studios
+ * Copyright (C) 2011 - 2013 Voxeliq Engine - http://www.voxeliq.org - https://github.com/raistlinthewiz/voxeliq
  *
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the Microsoft Public License (Ms-PL).
  */
 
 using Microsoft.Xna.Framework;

--- a/src/Engine/Configuration/Config.cs
+++ b/src/Engine/Configuration/Config.cs
@@ -1,6 +1,8 @@
 ﻿/*
- * Copyright (C) 2011-2012 Volumetric Studios
+ * Copyright (C) 2011 - 2013 Voxeliq Engine - http://www.voxeliq.org - https://github.com/raistlinthewiz/voxeliq
  *
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the Microsoft Public License (Ms-PL).
  */
 
 using Nini.Config;

--- a/src/Engine/Configuration/ConfigManager.cs
+++ b/src/Engine/Configuration/ConfigManager.cs
@@ -1,6 +1,8 @@
 ﻿/*
- * Copyright (C) 2011-2012 Volumetric Studios
+ * Copyright (C) 2011 - 2013 Voxeliq Engine - http://www.voxeliq.org - https://github.com/raistlinthewiz/voxeliq
  *
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the Microsoft Public License (Ms-PL).
  */
 
 using System;

--- a/src/Engine/Debugging/BoundingBoxRenderer.cs
+++ b/src/Engine/Debugging/BoundingBoxRenderer.cs
@@ -1,6 +1,8 @@
 ﻿/*
- * Copyright (C) 2011-2012 Volumetric Studios
+ * Copyright (C) 2011 - 2013 Voxeliq Engine - http://www.voxeliq.org - https://github.com/raistlinthewiz/voxeliq
  *
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the Microsoft Public License (Ms-PL).
  */
 
 using Microsoft.Xna.Framework;

--- a/src/Engine/Debugging/InGameDebugger.cs
+++ b/src/Engine/Debugging/InGameDebugger.cs
@@ -1,6 +1,8 @@
 ﻿/*
- * Copyright (C) 2011-2012 Volumetric Studios
+ * Copyright (C) 2011 - 2013 Voxeliq Engine - http://www.voxeliq.org - https://github.com/raistlinthewiz/voxeliq
  *
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the Microsoft Public License (Ms-PL).
  */
 
 using Microsoft.Xna.Framework;

--- a/src/Engine/Debugging/Layout.cs
+++ b/src/Engine/Debugging/Layout.cs
@@ -1,4 +1,11 @@
-﻿using System;
+﻿/*
+ * Copyright (C) 2011 - 2013 Voxeliq Engine - http://www.voxeliq.org - https://github.com/raistlinthewiz/voxeliq
+ *
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the Microsoft Public License (Ms-PL).
+ */
+
+using System;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 

--- a/src/Engine/Debugging/Profiling/Profiler.cs
+++ b/src/Engine/Debugging/Profiling/Profiler.cs
@@ -1,6 +1,8 @@
 ﻿/*
- * Copyright (C) 2011-2012 Volumetric Studios
+ * Copyright (C) 2011 - 2013 Voxeliq Engine - http://www.voxeliq.org - https://github.com/raistlinthewiz/voxeliq
  *
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the Microsoft Public License (Ms-PL).
  */
 
 using System;

--- a/src/Engine/Debugging/Statistics.cs
+++ b/src/Engine/Debugging/Statistics.cs
@@ -1,6 +1,8 @@
 ﻿/*
- * Copyright (C) 2011-2012 Volumetric Studios
+ * Copyright (C) 2011 - 2013 Voxeliq Engine - http://www.voxeliq.org - https://github.com/raistlinthewiz/voxeliq
  *
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the Microsoft Public License (Ms-PL).
  */
 
 using System;

--- a/src/Engine/Debugging/StatisticsGraphs.cs
+++ b/src/Engine/Debugging/StatisticsGraphs.cs
@@ -1,6 +1,8 @@
 ﻿/*
- * Copyright (C) 2011-2012 Volumetric Studios
+ * Copyright (C) 2011 - 2013 Voxeliq Engine - http://www.voxeliq.org - https://github.com/raistlinthewiz/voxeliq
  *
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the Microsoft Public License (Ms-PL).
  */
 
 using System;

--- a/src/Engine/Debugging/StringBuilderExtensions.cs
+++ b/src/Engine/Debugging/StringBuilderExtensions.cs
@@ -1,4 +1,11 @@
-﻿using System;
+﻿/*
+ * Copyright (C) 2011 - 2013 Voxeliq Engine - http://www.voxeliq.org - https://github.com/raistlinthewiz/voxeliq
+ *
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the Microsoft Public License (Ms-PL).
+ */
+
+using System;
 using System.Globalization;
 using System.Text;
 

--- a/src/Engine/Debugging/TimeRuler.cs
+++ b/src/Engine/Debugging/TimeRuler.cs
@@ -1,4 +1,11 @@
-﻿using System;
+﻿/*
+ * Copyright (C) 2011 - 2013 Voxeliq Engine - http://www.voxeliq.org - https://github.com/raistlinthewiz/voxeliq
+ *
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the Microsoft Public License (Ms-PL).
+ */
+
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;

--- a/src/Engine/Effects/PostProcessing/Bloom/BloomComponent.cs
+++ b/src/Engine/Effects/PostProcessing/Bloom/BloomComponent.cs
@@ -1,4 +1,11 @@
-﻿using System;
+﻿/*
+ * Copyright (C) 2011 - 2013 Voxeliq Engine - http://www.voxeliq.org - https://github.com/raistlinthewiz/voxeliq
+ *
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the Microsoft Public License (Ms-PL).
+ */
+
+using System;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 

--- a/src/Engine/Effects/PostProcessing/Bloom/BloomSettings.cs
+++ b/src/Engine/Effects/PostProcessing/Bloom/BloomSettings.cs
@@ -1,4 +1,11 @@
-﻿namespace VoxeliqEngine.Effects.PostProcessing.Bloom
+﻿/*
+ * Copyright (C) 2011 - 2013 Voxeliq Engine - http://www.voxeliq.org - https://github.com/raistlinthewiz/voxeliq
+ *
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the Microsoft Public License (Ms-PL).
+ */
+
+namespace VoxeliqEngine.Effects.PostProcessing.Bloom
 {
     public class BloomSettings
     {

--- a/src/Engine/Engine/Settings.cs
+++ b/src/Engine/Engine/Settings.cs
@@ -1,6 +1,8 @@
 ﻿/*
- * Copyright (C) 2011-2012 Volumetric Studios
+ * Copyright (C) 2011 - 2013 Voxeliq Engine - http://www.voxeliq.org - https://github.com/raistlinthewiz/voxeliq
  *
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the Microsoft Public License (Ms-PL).
  */
 
 namespace VoxeliqEngine.Engine

--- a/src/Engine/Graphics/Camera.cs
+++ b/src/Engine/Graphics/Camera.cs
@@ -1,6 +1,8 @@
 ﻿/*
- * Copyright (C) 2011-2012 Volumetric Studios
+ * Copyright (C) 2011 - 2013 Voxeliq Engine - http://www.voxeliq.org - https://github.com/raistlinthewiz/voxeliq
  *
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the Microsoft Public License (Ms-PL).
  */
 
 using Microsoft.Xna.Framework;

--- a/src/Engine/Graphics/Drawing/PrimitiveBatch.cs
+++ b/src/Engine/Graphics/Drawing/PrimitiveBatch.cs
@@ -1,6 +1,8 @@
 ﻿/*
- * Copyright (C) 2011-2012 Volumetric Studios
+ * Copyright (C) 2011 - 2013 Voxeliq Engine - http://www.voxeliq.org - https://github.com/raistlinthewiz/voxeliq
  *
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the Microsoft Public License (Ms-PL).
  */
 
 using System;

--- a/src/Engine/Graphics/GraphicsConfig.cs
+++ b/src/Engine/Graphics/GraphicsConfig.cs
@@ -1,6 +1,8 @@
 ﻿/*
- * Copyright (C) 2011-2012 Volumetric Studios
+ * Copyright (C) 2011 - 2013 Voxeliq Engine - http://www.voxeliq.org - https://github.com/raistlinthewiz/voxeliq
  *
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the Microsoft Public License (Ms-PL).
  */
 
 using VoxeliqEngine.Configuration;

--- a/src/Engine/Graphics/GraphicsManager.cs
+++ b/src/Engine/Graphics/GraphicsManager.cs
@@ -1,6 +1,8 @@
 ﻿/*
- * Copyright (C) 2011-2012 Volumetric Studios
+ * Copyright (C) 2011 - 2013 Voxeliq Engine - http://www.voxeliq.org - https://github.com/raistlinthewiz/voxeliq
  *
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the Microsoft Public License (Ms-PL).
  */
 
 using Microsoft.Xna.Framework;

--- a/src/Engine/Graphics/Rasterizer.cs
+++ b/src/Engine/Graphics/Rasterizer.cs
@@ -1,6 +1,8 @@
 ﻿/*
- * Copyright (C) 2011-2012 Volumetric Studios
+ * Copyright (C) 2011 - 2013 Voxeliq Engine - http://www.voxeliq.org - https://github.com/raistlinthewiz/voxeliq
  *
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the Microsoft Public License (Ms-PL).
  */
 
 using Microsoft.Xna.Framework.Graphics;

--- a/src/Engine/IO/FileHelper.cs
+++ b/src/Engine/IO/FileHelper.cs
@@ -1,6 +1,8 @@
 ﻿/*
- * Copyright (C) 2011-2012 Volumetric Studios
+ * Copyright (C) 2011 - 2013 Voxeliq Engine - http://www.voxeliq.org - https://github.com/raistlinthewiz/voxeliq
  *
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the Microsoft Public License (Ms-PL).
  */
 
 using System.Collections.Generic;

--- a/src/Engine/Input/InputManager.cs
+++ b/src/Engine/Input/InputManager.cs
@@ -1,6 +1,8 @@
 ﻿/*
- * Copyright (C) 2011-2012 Volumetric Studios
+ * Copyright (C) 2011 - 2013 Voxeliq Engine - http://www.voxeliq.org - https://github.com/raistlinthewiz/voxeliq
  *
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the Microsoft Public License (Ms-PL).
  */
 
 using Microsoft.Xna.Framework;

--- a/src/Engine/Interface/UserInterface.cs
+++ b/src/Engine/Interface/UserInterface.cs
@@ -1,6 +1,8 @@
 ﻿/*
- * Copyright (C) 2011-2012 Volumetric Studios
+ * Copyright (C) 2011 - 2013 Voxeliq Engine - http://www.voxeliq.org - https://github.com/raistlinthewiz/voxeliq
  *
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the Microsoft Public License (Ms-PL).
  */
 
 using Microsoft.Xna.Framework;

--- a/src/Engine/Logging/LogConfig.cs
+++ b/src/Engine/Logging/LogConfig.cs
@@ -1,6 +1,8 @@
 ﻿/*
- * Copyright (C) 2011-2012 Volumetric Studios
+ * Copyright (C) 2011 - 2013 Voxeliq Engine - http://www.voxeliq.org - https://github.com/raistlinthewiz/voxeliq
  *
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the Microsoft Public License (Ms-PL).
  */
 
 using VoxeliqEngine.Configuration;

--- a/src/Engine/Logging/TinyLogger.cs
+++ b/src/Engine/Logging/TinyLogger.cs
@@ -1,6 +1,8 @@
 ﻿/*
- * Copyright (C) 2011-2012 Volumetric Studios
+ * Copyright (C) 2011 - 2013 Voxeliq Engine - http://www.voxeliq.org - https://github.com/raistlinthewiz/voxeliq
  *
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the Microsoft Public License (Ms-PL).
  */
 
 using System;

--- a/src/Engine/Player.cs
+++ b/src/Engine/Player.cs
@@ -1,6 +1,8 @@
 ﻿/*
- * Copyright (C) 2011-2012 Volumetric Studios
+ * Copyright (C) 2011 - 2013 Voxeliq Engine - http://www.voxeliq.org - https://github.com/raistlinthewiz/voxeliq
  *
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the Microsoft Public License (Ms-PL).
  */
 
 using Microsoft.Xna.Framework;

--- a/src/Engine/Shovel.cs
+++ b/src/Engine/Shovel.cs
@@ -1,6 +1,8 @@
 ﻿/*
- * Copyright (C) 2011-2012 Volumetric Studios
+ * Copyright (C) 2011 - 2013 Voxeliq Engine - http://www.voxeliq.org - https://github.com/raistlinthewiz/voxeliq
  *
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the Microsoft Public License (Ms-PL).
  */
 
 using Microsoft.Xna.Framework;

--- a/src/Engine/Texture/DualTextured.cs
+++ b/src/Engine/Texture/DualTextured.cs
@@ -1,6 +1,8 @@
 ﻿/*
- * Copyright (C) 2011-2012 Volumetric Studios
+ * Copyright (C) 2011 - 2013 Voxeliq Engine - http://www.voxeliq.org - https://github.com/raistlinthewiz/voxeliq
  *
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the Microsoft Public License (Ms-PL).
  */
 
 using System;

--- a/src/Engine/Texture/TextureHelper.cs
+++ b/src/Engine/Texture/TextureHelper.cs
@@ -1,6 +1,8 @@
 ﻿/*
- * Copyright (C) 2011-2012 Volumetric Studios
+ * Copyright (C) 2011 - 2013 Voxeliq Engine - http://www.voxeliq.org - https://github.com/raistlinthewiz/voxeliq
  *
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the Microsoft Public License (Ms-PL).
  */
 
 using System.Collections.Generic;

--- a/src/Engine/Universe/BlockVertex.cs
+++ b/src/Engine/Universe/BlockVertex.cs
@@ -1,6 +1,8 @@
 ﻿/*
- * Copyright (C) 2011-2012 Volumetric Studios
+ * Copyright (C) 2011 - 2013 Voxeliq Engine - http://www.voxeliq.org - https://github.com/raistlinthewiz/voxeliq
  *
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the Microsoft Public License (Ms-PL).
  */
 
 using System;

--- a/src/Engine/Universe/Fogger.cs
+++ b/src/Engine/Universe/Fogger.cs
@@ -1,4 +1,11 @@
-﻿using Microsoft.Xna.Framework;
+﻿/*
+ * Copyright (C) 2011 - 2013 Voxeliq Engine - http://www.voxeliq.org - https://github.com/raistlinthewiz/voxeliq
+ *
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the Microsoft Public License (Ms-PL).
+ */
+
+using Microsoft.Xna.Framework;
 using VoxeliqEngine.Chunks;
 using VoxeliqEngine.Logging;
 

--- a/src/Engine/Universe/PositionedBlock.cs
+++ b/src/Engine/Universe/PositionedBlock.cs
@@ -1,6 +1,8 @@
 ﻿/*
- * Copyright (C) 2011-2012 Volumetric Studios
+ * Copyright (C) 2011 - 2013 Voxeliq Engine - http://www.voxeliq.org - https://github.com/raistlinthewiz/voxeliq
  *
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the Microsoft Public License (Ms-PL).
  */
 
 using VoxeliqEngine.Blocks;

--- a/src/Engine/Universe/Sky.cs
+++ b/src/Engine/Universe/Sky.cs
@@ -1,6 +1,8 @@
 ﻿/*
- * Copyright (C) 2011-2012 Volumetric Studios
+ * Copyright (C) 2011 - 2013 Voxeliq Engine - http://www.voxeliq.org - https://github.com/raistlinthewiz/voxeliq
  *
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the Microsoft Public License (Ms-PL).
  */
 
 using System;

--- a/src/Engine/Universe/Time.cs
+++ b/src/Engine/Universe/Time.cs
@@ -1,4 +1,11 @@
-﻿using System;
+﻿/*
+ * Copyright (C) 2011 - 2013 Voxeliq Engine - http://www.voxeliq.org - https://github.com/raistlinthewiz/voxeliq
+ *
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the Microsoft Public License (Ms-PL).
+ */
+
+using System;
 
 namespace VoxeliqEngine.Universe
 {

--- a/src/Engine/Universe/Weapon.cs
+++ b/src/Engine/Universe/Weapon.cs
@@ -1,6 +1,8 @@
 ﻿/*
- * Copyright (C) 2011-2012 Volumetric Studios
+ * Copyright (C) 2011 - 2013 Voxeliq Engine - http://www.voxeliq.org - https://github.com/raistlinthewiz/voxeliq
  *
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the Microsoft Public License (Ms-PL).
  */
 
 using Microsoft.Xna.Framework;

--- a/src/Engine/Universe/World.cs
+++ b/src/Engine/Universe/World.cs
@@ -1,6 +1,8 @@
 ﻿/*
- * Copyright (C) 2011-2012 Volumetric Studios
+ * Copyright (C) 2011 - 2013 Voxeliq Engine - http://www.voxeliq.org - https://github.com/raistlinthewiz/voxeliq
  *
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the Microsoft Public License (Ms-PL).
  */
 
 using Microsoft.Xna.Framework;

--- a/src/Engine/Utils/DoubleIndexedDictionary.cs
+++ b/src/Engine/Utils/DoubleIndexedDictionary.cs
@@ -1,6 +1,8 @@
 ﻿/*
- * Copyright (C) 2011-2012 Volumetric Studios
+ * Copyright (C) 2011 - 2013 Voxeliq Engine - http://www.voxeliq.org - https://github.com/raistlinthewiz/voxeliq
  *
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the Microsoft Public License (Ms-PL).
  */
 
 using System;

--- a/src/Engine/Utils/Mathematics/FastRandom.cs
+++ b/src/Engine/Utils/Mathematics/FastRandom.cs
@@ -1,6 +1,8 @@
 ﻿/*
- * Copyright (C) 2011-2012 Volumetric Studios
+ * Copyright (C) 2011 - 2013 Voxeliq Engine - http://www.voxeliq.org - https://github.com/raistlinthewiz/voxeliq
  *
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the Microsoft Public License (Ms-PL).
  */
 
 // Credits goes to SharpNEAT project: http://sharpneat.sourceforge.net/ (GPL v2/LGPL).

--- a/src/Engine/Utils/Mathematics/MathHelper.cs
+++ b/src/Engine/Utils/Mathematics/MathHelper.cs
@@ -1,6 +1,8 @@
 ﻿/*
- * Copyright (C) 2011-2012 Volumetric Studios
+ * Copyright (C) 2011 - 2013 Voxeliq Engine - http://www.voxeliq.org - https://github.com/raistlinthewiz/voxeliq
  *
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the Microsoft Public License (Ms-PL).
  */
 
 using System;

--- a/src/Engine/Utils/Randomization/Procedural/PerlinNoise.cs
+++ b/src/Engine/Utils/Randomization/Procedural/PerlinNoise.cs
@@ -1,4 +1,11 @@
-﻿using System;
+﻿/*
+ * Copyright (C) 2011 - 2013 Voxeliq Engine - http://www.voxeliq.org - https://github.com/raistlinthewiz/voxeliq
+ *
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the Microsoft Public License (Ms-PL).
+ */
+
+using System;
 
 namespace VoxeliqEngine.Utils.Randomization.Procedural
 {

--- a/src/Engine/Utils/Randomization/Procedural/SimplexNoise.cs
+++ b/src/Engine/Utils/Randomization/Procedural/SimplexNoise.cs
@@ -1,6 +1,8 @@
 ﻿/*
- * Copyright (C) 2011-2012 Volumetric Studios
+ * Copyright (C) 2011 - 2013 Voxeliq Engine - http://www.voxeliq.org - https://github.com/raistlinthewiz/voxeliq
  *
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the Microsoft Public License (Ms-PL).
  */
 
 using System;

--- a/src/Engine/Utils/SparseMatrix.cs
+++ b/src/Engine/Utils/SparseMatrix.cs
@@ -1,6 +1,8 @@
 ﻿/*
- * Copyright (C) 2011-2012 Volumetric Studios
+ * Copyright (C) 2011 - 2013 Voxeliq Engine - http://www.voxeliq.org - https://github.com/raistlinthewiz/voxeliq
  *
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the Microsoft Public License (Ms-PL).
  */
 
 using System.Collections.Generic;

--- a/src/Engine/Utils/Vector/Vector2Int.cs
+++ b/src/Engine/Utils/Vector/Vector2Int.cs
@@ -1,6 +1,8 @@
 ﻿/*
- * Copyright (C) 2011-2012 Volumetric Studios
+ * Copyright (C) 2011 - 2013 Voxeliq Engine - http://www.voxeliq.org - https://github.com/raistlinthewiz/voxeliq
  *
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the Microsoft Public License (Ms-PL).
  */
 
 namespace VoxeliqEngine.Utils.Vector

--- a/src/Engine/Utils/Vector/Vector3Int.cs
+++ b/src/Engine/Utils/Vector/Vector3Int.cs
@@ -1,6 +1,8 @@
 ﻿/*
- * Copyright (C) 2011-2012 Volumetric Studios
+ * Copyright (C) 2011 - 2013 Voxeliq Engine - http://www.voxeliq.org - https://github.com/raistlinthewiz/voxeliq
  *
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the Microsoft Public License (Ms-PL).
  */
 
 using Microsoft.Xna.Framework;

--- a/src/Engine/Utils/Vector/Vector4Byte.cs
+++ b/src/Engine/Utils/Vector/Vector4Byte.cs
@@ -1,6 +1,8 @@
 ﻿/*
- * Copyright (C) 2011-2012 Volumetric Studios
+ * Copyright (C) 2011 - 2013 Voxeliq Engine - http://www.voxeliq.org - https://github.com/raistlinthewiz/voxeliq
  *
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the Microsoft Public License (Ms-PL).
  */
 
 using System;

--- a/src/Engine/VoxeliqEngine.Windows.XNA.csproj
+++ b/src/Engine/VoxeliqEngine.Windows.XNA.csproj
@@ -13,7 +13,7 @@
     <TargetFrameworkProfile>Client</TargetFrameworkProfile>
     <XnaFrameworkVersion>v4.0</XnaFrameworkVersion>
     <XnaPlatform>Windows</XnaPlatform>
-    <XnaProfile>Reach</XnaProfile>
+    <XnaProfile>HiDef</XnaProfile>
     <XnaCrossPlatformGroupID>696a1687-6361-40bf-94dd-3e3a8cab37d4</XnaCrossPlatformGroupID>
     <XnaOutputType>Library</XnaOutputType>
   </PropertyGroup>
@@ -125,6 +125,13 @@
     <Compile Include="Utils\Vector\Vector2Int.cs" />
     <Compile Include="Utils\Vector\Vector3Int.cs" />
     <Compile Include="Utils\Vector\Vector4Byte.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Content\Content.contentproj">
+      <Project>{9896E4F9-E78C-40A6-8C1B-6EF4A714E34B}</Project>
+      <Name>Content</Name>
+      <XnaReferenceType>Content</XnaReferenceType>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\XNA Game Studio\Microsoft.Xna.GameStudio.targets" />

--- a/src/game/Program.cs
+++ b/src/game/Program.cs
@@ -1,6 +1,8 @@
 /*
- * Copyright (C) 2011-2012 Volumetric Studios
+ * Copyright (C) 2011 - 2013 Voxeliq Engine - http://www.voxeliq.org - https://github.com/raistlinthewiz/voxeliq
  *
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the Microsoft Public License (Ms-PL).
  */
 
 using System;

--- a/src/game/SampleGame.Windows.MonoGame.csproj
+++ b/src/game/SampleGame.Windows.MonoGame.csproj
@@ -147,7 +147,9 @@
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\XNA Game Studio\Microsoft.Xna.GameStudio.targets" />
   <PropertyGroup>
-    <PostBuildEvent>xcopy $(TargetDir)..\xna\Content $(TargetDir)Content /Y /E /D</PostBuildEvent>
+    <PostBuildEvent>mkdir $(TargetDir)Content
+xcopy $(TargetDir)..\xna\Content $(TargetDir)Content /Y /E /D
+xcopy $(TargetDir)..\..\..\..\dep\monogame\windows $(TargetDir) /Y /E /D</PostBuildEvent>
   </PropertyGroup>
   <!--
       To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/game/VoxeliqGame.cs
+++ b/src/game/VoxeliqGame.cs
@@ -1,6 +1,8 @@
 /*
- * Copyright (C) 2011-2012 Volumetric Studios
+ * Copyright (C) 2011 - 2013 Voxeliq Engine - http://www.voxeliq.org - https://github.com/raistlinthewiz/voxeliq
  *
+ * This program is free software; you can redistribute it and/or modify 
+ * it under the terms of the Microsoft Public License (Ms-PL).
  */
 
 using System.Reflection;


### PR DESCRIPTION
- Fixed the XNA project file which was not compiling the resources correctly.
- Fixed post build events for monogame project. Should be now automatically copying Content\ and other required deps.
